### PR TITLE
update to ubi 8.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /build
 COPY . .
 RUN make test build
 
-FROM registry.access.redhat.com/ubi8-minimal:8.8
+FROM registry.access.redhat.com/ubi8-minimal:8.9
 COPY --from=builder /build/alert-translator  /bin/alert-translator
 RUN microdnf update -y && microdnf install -y git && microdnf install -y ca-certificates
 


### PR DESCRIPTION
[APPSRE-9817](https://issues.redhat.com/browse/APPSRE-9817)

Remediate high level CVEs by updating the ubi image. Tested locally by building the new image and running that (no issues as far as I can see).