### PR TITLE
update golang to 1.20.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/golang:1.20.1 as builder
+FROM quay.io/app-sre/golang:1.20.6 as builder
 WORKDIR /build
 COPY . .
 RUN make test build


### PR DESCRIPTION
This is to address some vulnerabilities occurring in 1.20.1 of the builder image.