### PR TITLE
disable cgo for builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 
 .PHONY: build
 build:
-	go build -o $(NAME) .
+	CGO_ENABLED=0 GOOS=$(GOOS) go build -o $(NAME) .
 
 .PHONY: image
 image:


### PR DESCRIPTION
Follow the example of other [app-sre go binaries](https://github.com/app-sre/go-qontract-reconcile/blob/main/Makefile#L29C2-L29C13) by disabling CGO to build static binaries.