### PR TITLE
Migrate builder image, update entrypoint image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM quay.io/app-sre/golang:1.23.1 as builder
-WORKDIR /build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.21.13-1.1727869850 as builder
+USER 0
+WORKDIR /workspace
 COPY . .
 RUN make test build
 
-FROM registry.access.redhat.com/ubi8-minimal:8.10
-COPY --from=builder /build/alert-translator  /bin/alert-translator
+FROM registry.access.redhat.com/ubi8-minimal:8.10-1086
+COPY --from=builder /workspace/alert-translator  /bin/alert-translator
 RUN microdnf update -y && microdnf install -y git && microdnf install -y ca-certificates
 
 ENTRYPOINT  [ "/bin/alert-translator" ]


### PR DESCRIPTION
This MR migrates the go build process from app-sre/golang (mirrored from external sources) to Red Hat's ubi8/go-toolset.

In addition, it updates the base image for the entrypoint.