### PR TITLE
update ubi image to 8.10-1130

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY . .
 RUN make test build
 
-FROM registry.access.redhat.com/ubi8-minimal:8.10-1086
+FROM registry.access.redhat.com/ubi8-minimal:8.10-1130
 COPY --from=builder /workspace/alert-translator  /bin/alert-translator
 RUN microdnf update -y && microdnf install -y git && microdnf install -y ca-certificates
 


### PR DESCRIPTION
[OSD-26520](https://issues.redhat.com/browse/OSD-26520)

Updating base image to address CVE's. Tested by building the image locally and running the sample payload from the README. Seems to forward successfully 
