### PR TITLE
Upgrade to ubi9 image and latest Go 1.24 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.23.6-1.1744600118 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 as builder
 USER 0
 WORKDIR /workspace
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/app-sre/alert-translator
 
-go 1.23
+go 1.24
 
 require (
 	github.com/prometheus/alertmanager v0.28.1


### PR DESCRIPTION
Addresses outstanding high-severity CVEs:
- CVE-2025-48384
- CVE-2025-48385
- CVE-2025-49794
- CVE-2025-49796
- CVE-2025-6020

Validations:
Image was built using ubi9 / Go 1.24 image ( `make all` ) and sample curl command was ran against locally running process to confirm alert was processed.