### PR TITLE
Upgrade run image to ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY . .
 RUN make test build
 
-FROM registry.access.redhat.com/ubi8-minimal:8.10-1179.1741863533
+FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
 COPY --from=builder /workspace/alert-translator  /bin/alert-translator
 RUN microdnf update -y && microdnf install -y git && microdnf install -y ca-certificates
 


### PR DESCRIPTION
Follow up to https://github.com/app-sre/alert-translator/pull/24 , which upgraded builder image.

This addresses CVEs related to `git` and `libxml2`